### PR TITLE
Troubleshooting

### DIFF
--- a/Assets/Graphics/Materials/Star.mat
+++ b/Assets/Graphics/Materials/Star.mat
@@ -75,3 +75,4 @@ Material:
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Scripts/Celestial/Shaders/Compute/Shading/MoonShading.compute
+++ b/Assets/Scripts/Celestial/Shaders/Compute/Shading/MoonShading.compute
@@ -20,7 +20,7 @@ StructuredBuffer<float4> ejectaCraters;
 int numEjectaCraters;
 
 float calcSphereNoise(float3 pos) {
-	float sphereNoise = 1.#INF;
+	float sphereNoise = 3.402823466e+38F;
 	for (int i = 0; i < numRandomPoints; i ++) {
 		float3 sphereCentre = points[i].xyz;
 		float sphereRadius = points[i].w;

--- a/Assets/Scripts/Game/Controllers/PlayerController.cs
+++ b/Assets/Scripts/Game/Controllers/PlayerController.cs
@@ -37,6 +37,8 @@ public class PlayerController : GravityObject {
 	float pitch;
 	float smoothYaw;
 	float smoothPitch;
+	
+	float smoothYawOld;
 
 	float yawSmoothV;
 	float pitchSmoothV;
@@ -45,6 +47,8 @@ public class PlayerController : GravityObject {
 	Vector3 cameraLocalPos;
 	Vector3 smoothVelocity;
 	Vector3 smoothVRef;
+	
+	bool isGrounded;
 
 	// Jetpack
 	bool usingJetpack;
@@ -77,33 +81,50 @@ public class PlayerController : GravityObject {
 	}
 
 	void Update () {
-		HandleMovement ();
+		HandleInput();
+
+		// Refuel jetpack
+		if (Time.time - lastJetpackUseTime > jetpackRefuelDelay) {
+			jetpackFuelPercent = Mathf.Clamp01 (jetpackFuelPercent + Time.deltaTime / jetpackRefuelTime);
+		}
+
+		// Handle animations
+		float currentSpeed = smoothVelocity.magnitude;
+		float animationSpeedPercent = (currentSpeed <= walkSpeed) ? currentSpeed / walkSpeed / 2 : currentSpeed / runSpeed;
+		animator.SetBool ("Grounded", isGrounded);
+		animator.SetFloat ("Speed", animationSpeedPercent);
 	}
 
-	void HandleMovement () {
-		HandleEditorInput ();
-		if (Time.timeScale == 0) {
-			return;
-		}
+	void HandleInput()
+	{
+		HandleEditorInput();
+
 		// Look input
 		yaw += Input.GetAxisRaw ("Mouse X") * inputSettings.mouseSensitivity / 10 * mouseSensitivityMultiplier;
 		pitch -= Input.GetAxisRaw ("Mouse Y") * inputSettings.mouseSensitivity / 10 * mouseSensitivityMultiplier;
 		pitch = Mathf.Clamp (pitch, pitchMinMax.x, pitchMinMax.y);
 		float mouseSmoothTime = Mathf.Lerp (0.01f, maxMouseSmoothTime, inputSettings.mouseSmoothing);
 		smoothPitch = Mathf.SmoothDampAngle (smoothPitch, pitch, ref pitchSmoothV, mouseSmoothTime);
-		float smoothYawOld = smoothYaw;
+		smoothYawOld = smoothYaw;
 		smoothYaw = Mathf.SmoothDampAngle (smoothYaw, yaw, ref yawSmoothV, mouseSmoothTime);
-		if (!debug_playerFrozen && Time.timeScale > 0) {
-			cam.transform.localEulerAngles = Vector3.right * smoothPitch;
-			transform.Rotate (Vector3.up * Mathf.DeltaAngle (smoothYawOld, smoothYaw), Space.Self);
-		}
 
-		// Movement
-		bool isGrounded = IsGrounded ();
+		// Movement input
+		isGrounded = IsGrounded ();
 		Vector3 input = new Vector3 (Input.GetAxisRaw ("Horizontal"), 0, Input.GetAxisRaw ("Vertical"));
 		bool running = Input.GetKey (KeyCode.LeftShift);
 		targetVelocity = transform.TransformDirection (input.normalized) * ((running) ? runSpeed : walkSpeed);
 		smoothVelocity = Vector3.SmoothDamp (smoothVelocity, targetVelocity, ref smoothVRef, (isGrounded) ? vSmoothTime : airSmoothTime);
+	}
+
+	void HandleMovement () {
+		if (Time.timeScale == 0) {
+			return;
+		}
+
+		if (!debug_playerFrozen && Time.timeScale > 0) {
+			cam.transform.localEulerAngles = Vector3.right * smoothPitch;
+			transform.Rotate (Vector3.up * Mathf.DeltaAngle (smoothYawOld, smoothYaw), Space.Self);
+		}
 
 		//bool inWater = referenceBody
 		if (isGrounded) {
@@ -128,17 +149,6 @@ public class PlayerController : GravityObject {
 		} else {
 			usingJetpack = false;
 		}
-
-		// Refuel jetpack
-		if (Time.time - lastJetpackUseTime > jetpackRefuelDelay) {
-			jetpackFuelPercent = Mathf.Clamp01 (jetpackFuelPercent + Time.deltaTime / jetpackRefuelTime);
-		}
-
-		// Handle animations
-		float currentSpeed = smoothVelocity.magnitude;
-		float animationSpeedPercent = (currentSpeed <= walkSpeed) ? currentSpeed / walkSpeed / 2 : currentSpeed / runSpeed;
-		animator.SetBool ("Grounded", isGrounded);
-		animator.SetFloat ("Speed", animationSpeedPercent);
 	}
 
 	bool IsGrounded () {
@@ -165,6 +175,8 @@ public class PlayerController : GravityObject {
 	}
 
 	void FixedUpdate () {
+		HandleMovement();
+		
 		CelestialBody[] bodies = NBodySimulation.Bodies;
 		Vector3 gravityOfNearestBody = Vector3.zero;
 		float nearestSurfaceDst = float.MaxValue;
@@ -188,7 +200,7 @@ public class PlayerController : GravityObject {
 
 		// Rotate to align with gravity up
 		Vector3 gravityUp = -gravityOfNearestBody.normalized;
-		rb.rotation = Quaternion.FromToRotation (transform.up, gravityUp) * rb.rotation;
+		transform.rotation = Quaternion.FromToRotation (transform.up, gravityUp) * transform.rotation;
 
 		// Move
 		rb.MovePosition (rb.position + smoothVelocity * Time.fixedDeltaTime);

--- a/Assets/Scripts/Game/Controllers/PlayerController.cs
+++ b/Assets/Scripts/Game/Controllers/PlayerController.cs
@@ -81,6 +81,10 @@ public class PlayerController : GravityObject {
 	}
 
 	void Update () {
+		if (Time.timeScale == 0) {
+			return;
+		}
+		
 		HandleInput();
 
 		// Refuel jetpack
@@ -117,10 +121,6 @@ public class PlayerController : GravityObject {
 	}
 
 	void HandleMovement () {
-		if (Time.timeScale == 0) {
-			return;
-		}
-
 		if (!debug_playerFrozen && Time.timeScale > 0) {
 			cam.transform.localEulerAngles = Vector3.right * smoothPitch;
 			transform.Rotate (Vector3.up * Mathf.DeltaAngle (smoothYawOld, smoothYaw), Space.Self);
@@ -175,6 +175,10 @@ public class PlayerController : GravityObject {
 	}
 
 	void FixedUpdate () {
+		if (Time.timeScale == 0) {
+			return;
+		}
+		
 		HandleMovement();
 		
 		CelestialBody[] bodies = NBodySimulation.Bodies;

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,11 +1,12 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "1.2.16",
-    "com.unity.ide.rider": "1.1.4",
-    "com.unity.ide.vscode": "1.2.1",
-    "com.unity.test-framework": "1.1.14",
-    "com.unity.textmeshpro": "2.0.1",
-    "com.unity.timeline": "1.2.14",
+    "com.unity.collab-proxy": "1.3.9",
+    "com.unity.ide.rider": "2.0.7",
+    "com.unity.ide.visualstudio": "2.0.7",
+    "com.unity.ide.vscode": "1.2.3",
+    "com.unity.test-framework": "1.1.22",
+    "com.unity.textmeshpro": "3.0.1",
+    "com.unity.timeline": "1.4.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,21 +1,21 @@
 {
   "dependencies": {
     "com.unity.collab-proxy": {
-      "version": "1.2.16",
+      "version": "1.3.9",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.0",
+      "version": "1.0.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "1.1.4",
+      "version": "2.0.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -23,26 +23,35 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.ide.visualstudio": {
+      "version": "2.0.7",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.9"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.ide.vscode": {
-      "version": "1.2.1",
+      "version": "1.2.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.14",
+      "version": "1.1.22",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.0",
+        "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.textmeshpro": {
-      "version": "2.0.1",
+      "version": "3.0.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -51,10 +60,15 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.timeline": {
-      "version": "1.2.14",
+      "version": "1.4.6",
       "depth": 0,
       "source": "registry",
-      "dependencies": {},
+      "dependencies": {
+        "com.unity.modules.director": "1.0.0",
+        "com.unity.modules.animation": "1.0.0",
+        "com.unity.modules.audio": "1.0.0",
+        "com.unity.modules.particlesystem": "1.0.0"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.ugui": {
@@ -62,7 +76,8 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
-        "com.unity.modules.ui": "1.0.0"
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0"
       }
     },
     "com.unity.modules.ai": {
@@ -198,6 +213,18 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.uielementsnative": "1.0.0"
+      }
+    },
+    "com.unity.modules.uielementsnative": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       }

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -1,0 +1,43 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 61
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13964, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EnablePreviewPackages: 0
+  m_EnablePackageDependencies: 0
+  m_AdvancedSettingsExpanded: 1
+  m_ScopedRegistriesSettingsExpanded: 1
+  oneTimeWarningShown: 0
+  m_Registries:
+  - m_Id: main
+    m_Name: 
+    m_Url: https://packages.unity.com
+    m_Scopes: []
+    m_IsDefault: 1
+    m_Capabilities: 7
+  m_UserSelectedRegistryName: 
+  m_UserAddingNewScopedRegistry: 0
+  m_RegistryInfoDraft:
+    m_ErrorMessage: 
+    m_Original:
+      m_Id: 
+      m_Name: 
+      m_Url: 
+      m_Scopes: []
+      m_IsDefault: 0
+      m_Capabilities: 0
+    m_Modified: 0
+    m_Name: 
+    m_Url: 
+    m_Scopes:
+    - 
+    m_SelectedScopeIndex: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.4.1f1
-m_EditorVersionWithRevision: 2019.4.1f1 (e6c045e14e4e)
+m_EditorVersion: 2020.3.1f1
+m_EditorVersionWithRevision: 2020.3.1f1 (77a89f25062f)

--- a/ProjectSettings/VersionControlSettings.asset
+++ b/ProjectSettings/VersionControlSettings.asset
@@ -1,0 +1,8 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!890905787 &1
+VersionControlSettings:
+  m_ObjectHideFlags: 0
+  m_Mode: Visible Meta Files
+  m_CollabEditorSettings:
+    inProgressEnabled: 1

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!162 &1
+EditorUserSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 4
+  m_ConfigSettings:
+    RecentlyUsedScenePath-0:
+      value: 22424703114646680e0b0227036c6c1f1a160a6a1f31352428245326ece92021
+      flags: 0
+    vcSharedLogLevel:
+      value: 0d5e400f0650
+      flags: 0
+  m_VCAutomaticAdd: 1
+  m_VCDebugCom: 0
+  m_VCDebugCmd: 0
+  m_VCDebugOut: 0
+  m_SemanticMergeMode: 2
+  m_VCShowFailedCheckout: 1
+  m_VCOverwriteFailedCheckoutAssets: 1
+  m_VCProjectOverlayIcons: 1
+  m_VCHierarchyOverlayIcons: 1
+  m_VCOtherOverlayIcons: 1
+  m_VCAllowAsyncUpdate: 1


### PR DESCRIPTION
Commit 389eb16: The original shader could cause a compute shader compiling error which wasn't very easy to trace. It is better to set the initial value to a very large number instead to something that isn't supported by some systems.
Trace of this compiling error was seen in issue #24

Commit a265caa: Originally, moving astronaut or camera around would cause shaking similar to floating-point precision issues shaking. This should hopefully fix that.